### PR TITLE
fix - #15 replace wait(500) by wait for container to be in dom

### DIFF
--- a/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-COM-CERT-COM-NIEC1/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-COM-CERT-COM-NIEC1/integration_2019.spec.js
@@ -24,7 +24,8 @@ test("ITE-2019-COM-CERT-COM-NIEC1 certificate is rendered correctly", async t =>
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-COM-CERT-COM1/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-COM-CERT-COM1/integration_2019.spec.js
@@ -27,7 +27,8 @@ test("ITE-2019-COM-CERT-COM1 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-FUL-CERT-FULL-NIEC1/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-FUL-CERT-FULL-NIEC1/integration_2019.spec.js
@@ -24,7 +24,8 @@ test("ITE-2019-FUL-CERT-FULL-NIEC1 certificate is rendered correctly", async t =
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-FUL-CERT-FULL1/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/ite/ITE-2019-FUL-CERT-FULL1/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("ITE-2019-CERT-FULL1 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA1996-MAIN/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA1996-MAIN/integration.spec.js
@@ -24,7 +24,8 @@ test("FT-MAIN 1996 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2017-BMS(CLT)/integration_2017.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2017-BMS(CLT)/integration_2017.spec.js
@@ -24,7 +24,8 @@ test("BMS 2017 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2017-PHARM/integration_2017.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2017-PHARM/integration_2017.spec.js
@@ -25,7 +25,8 @@ test("PHARM 2017 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-BMS(CLT)/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-BMS(CLT)/integration_2018.spec.js
@@ -24,7 +24,8 @@ test("BMS 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-BMS(CLT)/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-BMS(CLT)/integration_2019.spec.js
@@ -24,7 +24,8 @@ test("BMS 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-DPP/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-DPP/integration_2018.spec.js
@@ -25,7 +25,8 @@ test("DPP 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-DPP/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-DPP/integration_2019.spec.js
@@ -24,7 +24,8 @@ test("DPP 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-ECH/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-ECH/integration_2018.spec.js
@@ -24,7 +24,8 @@ test("ECH 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-LDH/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-LDH/integration_2018.spec.js
@@ -25,7 +25,8 @@ test("LDH 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-LDH/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-LDH/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("LDH 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-MAIN/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-MAIN/integration_2018.spec.js
@@ -25,7 +25,8 @@ test("FT-MAIN 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-MAIN/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-MAIN/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("FT-MAIN 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-OPTION/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-OPTION/integration_2018.spec.js
@@ -25,7 +25,8 @@ test("OPTION 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-PHARM/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-PHARM/integration_2018.spec.js
@@ -25,7 +25,8 @@ test("PHARM 2018 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-PHARM/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2018-PHARM/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("PHARM 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2019-NIEC/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2019-NIEC/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("NIEC 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2019-OPT-NIEC/integration_2018.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-AA2019-OPT-NIEC/integration_2018.spec.js
@@ -25,7 +25,8 @@ test("OPTION-NIEC 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-PDPMAIN/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-PDPMAIN/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("PDP-MAIN 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-PTDMAIN/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-PTDMAIN/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("PTD-MAIN 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-SDCGN/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-SDCGN/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("PDP-SDCGN 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-SDPCN/integration_2019.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/np/NP-CET2019-SDPCN/integration_2019.spec.js
@@ -25,7 +25,8 @@ test("PDP-SGPCN 2019 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/ntu/2019-July-NTU-UG/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/ntu/2019-July-NTU-UG/integration.spec.js
@@ -28,7 +28,8 @@ test("NTU Undergrad certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/nyp/NYP-Main/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/nyp/NYP-Main/integration.spec.js
@@ -25,7 +25,8 @@ test("Graduation certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DCJP/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DCJP/integration.spec.js
@@ -25,7 +25,8 @@ test("CET Diploma Joint Poly certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DCN/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DCN/integration.spec.js
@@ -25,7 +25,8 @@ test("CET Diploma certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DCSU/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DCSU/integration.spec.js
@@ -24,7 +24,8 @@ test("CET Diploma SUSS certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DPLUS/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-DPLUS/integration.spec.js
@@ -24,7 +24,8 @@ test("DPLUS certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-MC/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-MC/integration.spec.js
@@ -24,7 +24,8 @@ test("MC certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-MCJP/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-MCJP/integration.spec.js
@@ -24,7 +24,8 @@ test("MC certificate Joint Poly is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-MCSU/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-C-MCSU/integration.spec.js
@@ -24,7 +24,8 @@ test("MC certificate SUSS is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-P-MAIN/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/rp/2018-P-MAIN/integration.spec.js
@@ -25,7 +25,8 @@ test("PET certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ftdip/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ftdip/test.spec.js
@@ -24,7 +24,8 @@ test("Full-time Diploma is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ftdipniec/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ftdipniec/test.spec.js
@@ -27,7 +27,8 @@ test("Full-time NIEC Diploma is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ftdipplus/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ftdipplus/test.spec.js
@@ -24,7 +24,8 @@ test("Full-time Diploma Plus is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ftpfp/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ftpfp/test.spec.js
@@ -24,7 +24,8 @@ test("Polytechnic Foundation Programme is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t.expect(templates).eql([
     { id: "certificate", label: "Certificate", template: undefined },

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptdip/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptdip/test.spec.js
@@ -25,7 +25,8 @@ test("Part-time Diploma is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptdip_certis/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptdip_certis/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Diploma with Certis is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptdipdpss/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptdipdpss/test.spec.js
@@ -28,7 +28,8 @@ test("Part-time Joint Diploma with Singapore Police Force is rendered correctly.
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptfsm/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptfsm/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Certificate with SCDF is rendered correctly.", async t => 
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptmc/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptmc/test.spec.js
@@ -25,7 +25,8 @@ test("Part-time Modular Certificate is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptmc_mod/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptmc_mod/test.spec.js
@@ -25,7 +25,8 @@ test("Part-time Modular Certificate of Modular Courses is rendered correctly.", 
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptpdc/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptpdc/test.spec.js
@@ -25,7 +25,8 @@ test("Part-time Post Diploma Certificate is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptpdc_mod/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptpdc_mod/test.spec.js
@@ -25,7 +25,8 @@ test("Part-time Post Diploma Certificate of Modular Courses is rendered correctl
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptpostdip/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptpostdip/test.spec.js
@@ -25,7 +25,8 @@ test("Part-time Post Diploma is rendered correctly.", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_bcaa/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_bcaa/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Specialist Diploma with BCAA is rendered correctly.", asyn
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_mha/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_mha/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Specialist Diploma with MHA is rendered correctly.", async
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_np/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_np/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Specialist Diploma with NP is rendered correctly.", async 
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_sit/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_sit/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Specialist Diploma with SIT is rendered correctly.", async
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_smu/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_smu/test.spec.js
@@ -26,7 +26,8 @@ test("Part-time Joint Specialist Diploma with SMU is rendered correctly.", async
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_suss/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsd_suss/test.spec.js
@@ -28,7 +28,8 @@ test("Part-time Joint Specialist Diploma with SUSS is rendered correctly.", asyn
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsdoh/test.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/edu/tp/ptsdoh/test.spec.js
@@ -29,7 +29,8 @@ test("Part-time Joint Specialist Diploma with SUSS is rendered correctly.", asyn
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_2002_2005/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_2002_2005/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEA_2002_2005 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_2006_NewSyll/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_2006_NewSyll/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEA_2006_NewSyll is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_2006_OldSyll/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_2006_OldSyll/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEA_2006_OldSyll is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_before_2002/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEA_before_2002/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEA_before_2002 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEN_NA_2008/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEN_NA_2008/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEN_NA_2008 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEN_NT_2008/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEN_NT_2008/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEN_NT_2008 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEN_before_2008/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEN_before_2008/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEN_before_2008 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEO/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_GCEO/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_GCEO is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_1980_1981/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_1980_1981/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_PSLE_1980_1981 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_1982_1992/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_1982_1992/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_PSLE_1982_1992 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_1993_2012/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_1993_2012/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_PSLE_1993_2012 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_2013/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_2013/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_PSLE_2013 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_before_1979/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/SOR_PSLE_before_1979/integration.spec.js
@@ -25,7 +25,8 @@ test("sg/gov/seab/SOR_PSLE_before_1979 is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-001/integration.spec.js
@@ -24,7 +24,8 @@ test("FQ001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-002/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-002/integration.spec.js
@@ -24,7 +24,8 @@ test("FQ002 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-004/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-004/integration.spec.js
@@ -25,7 +25,8 @@ test("FQ004 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-005/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-005/integration.spec.js
@@ -25,7 +25,8 @@ test("FQ005 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-006/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-006/integration.spec.js
@@ -25,7 +25,8 @@ test("FQ006 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/QUAL_Reprint/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/QUAL_Reprint/integration.spec.js
@@ -25,7 +25,8 @@ test("QUAL_Reprint certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_FQ_001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_FQ_001/integration.spec.js
@@ -25,7 +25,8 @@ test("SF_FQ_001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_FQ_002/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_FQ_002/integration.spec.js
@@ -25,7 +25,8 @@ test("SF_FQ_002 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_FQ_004/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_FQ_004/integration.spec.js
@@ -25,7 +25,8 @@ test("SF_FQ_004 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_001/integration.spec.js
@@ -25,7 +25,8 @@ test("SFSOA001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_HR_01/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_HR_01/integration.spec.js
@@ -25,7 +25,8 @@ test("SFSOAHR01 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_IT_001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_IT_001/integration.spec.js
@@ -25,7 +25,8 @@ test("SFSOAIT001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_MF_01/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_MF_01/integration.spec.js
@@ -25,7 +25,8 @@ test("SF_SOA_MF_01 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-001/integration.spec.js
@@ -25,7 +25,8 @@ test("SOA001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-002/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-002/integration.spec.js
@@ -25,7 +25,8 @@ test("SOA002 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-003/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-003/integration.spec.js
@@ -25,7 +25,8 @@ test("SOA003 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-ES-001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-ES-001/integration.spec.js
@@ -25,7 +25,8 @@ test("SOAES001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-FB-001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-FB-001/integration.spec.js
@@ -25,7 +25,8 @@ test("SOAFB001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-HR-01/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-HR-01/integration.spec.js
@@ -25,7 +25,8 @@ test("SOAHR01 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-IT-001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-IT-001/integration.spec.js
@@ -24,7 +24,8 @@ test("SOAIT001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-MF-01/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA-MF-01/integration.spec.js
@@ -25,7 +25,8 @@ test("SOAMF01 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA_Reprint/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA_Reprint/integration.spec.js
@@ -25,7 +25,8 @@ test("SOAReprint certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA_SV_001/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SOA_SV_001/integration.spec.js
@@ -25,7 +25,8 @@ test("SOA_SV_001 certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/integration.spec.js
@@ -25,7 +25,8 @@ test("Transcript certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/tech/2018-Geekout/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/tech/2018-Geekout/integration.spec.js
@@ -24,7 +24,8 @@ test("sg/gov/tech/2018-Geekout is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/CertificateTemplates/tlds/sg/gov/tech/Govtech-Demo-Cert/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/tech/Govtech-Demo-Cert/integration.spec.js
@@ -26,7 +26,8 @@ test("Govtech Demo certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)

--- a/src/components/FramelessViewer/integration-frameless-webview.spec.js
+++ b/src/components/FramelessViewer/integration-frameless-webview.spec.js
@@ -25,7 +25,8 @@ test("Default certificate is rendered correctly", async t => {
   });
 
   // Check content of window.opencerts.templates
-  await t.wait(500);
+  const container = Selector("#rendered-certificate .container");
+  await container(); // wait for document to be rendered
   const templates = await t.eval(() => window.opencerts.getTemplates());
   await t
     .expect(templates)


### PR DESCRIPTION
This MR fixes random failure when running `npm run integration:headless` (for example see #15)

The MR remove assertiong waiting for 500ms by assertion to wait for a specific element in a DOM to be present (`"#rendered-certificate .container"`)

closes #15