### PR TITLE
Fix/double scroll bar

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,13 +1,13 @@
 import { configure } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import debug from "debug"
-import { setConfig } from 'next/config'
-import { publicRuntimeConfig } from './next.config'
+import debug from "debug";
+import { setConfig } from "next/config";
+import { publicRuntimeConfig } from "./next.config";
 
 configure({ adapter: new Adapter() });
-setConfig({ publicRuntimeConfig })
+setConfig({ publicRuntimeConfig });
 
 // Jest swallows stderr from debug, so if process is called with DEBUG then redirect debug to console.log
 if (process.env.DEBUG) {
-    debug.log = console.log.bind(console) 
-} 
+  debug.log = console.log.bind(console);
+}

--- a/src/components/CertificateTemplates/tlds/sg/gov/tech/Govtech-Demo-Cert/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/tech/Govtech-Demo-Cert/certificate.js
@@ -118,7 +118,6 @@ const Template = ({ certificate }) => (
 );
 
 Template.propTypes = {
-  certificate: PropTypes.object.isRequired,
-  updateParentHeight: PropTypes.func
+  certificate: PropTypes.object.isRequired
 };
 export default Template;

--- a/src/components/CertificateTemplates/tlds/sg/gov/tech/Govtech-Demo-Cert/integration.spec.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/tech/Govtech-Demo-Cert/integration.spec.js
@@ -61,6 +61,5 @@ test("Govtech Demo certificate is rendered correctly", async t => {
   await t.eval(() => window.opencerts.selectTemplateTab(2));
 
   // Validate content of third tab
-  await t.wait(1000);
   await t.expect(Media.visible).ok();
 });

--- a/src/components/CertificateTemplates/utils/MultiCertificateRenderer.js
+++ b/src/components/CertificateTemplates/utils/MultiCertificateRenderer.js
@@ -34,13 +34,10 @@ const storeCanRenderTemplate = ({ whitelist, document }) => {
  */
 class MultiCertificateRenderer extends Component {
   componentDidMount() {
-    const { templates, updateParentHeight, updateParentTemplates } = this.props;
+    const { templates, updateParentTemplates } = this.props;
 
     // Templates
     updateParentTemplates(templates);
-
-    // Update Height
-    updateParentHeight();
   }
 
   render() {
@@ -49,8 +46,7 @@ class MultiCertificateRenderer extends Component {
       whitelist,
       templates,
       tabIndex,
-      obfuscateDocument,
-      updateParentHeight
+      obfuscateDocument
     } = this.props;
     const SelectedTemplateTab = templates[tabIndex].template;
     const allowedToRender = storeCanRenderTemplate({
@@ -62,7 +58,6 @@ class MultiCertificateRenderer extends Component {
         <SelectedTemplateTab
           certificate={document}
           handleObfuscation={obfuscateDocument}
-          updateParentHeight={updateParentHeight}
         />
       );
     }
@@ -75,7 +70,6 @@ MultiCertificateRenderer.propTypes = {
   templates: PropTypes.array.isRequired,
   document: PropTypes.object.isRequired,
   tabIndex: PropTypes.number.isRequired,
-  updateParentHeight: PropTypes.func,
   updateParentTemplates: PropTypes.func,
   obfuscateDocument: PropTypes.func
 };

--- a/src/components/CertificateTemplates/utils/MultiCertificateRenderer.test.js
+++ b/src/components/CertificateTemplates/utils/MultiCertificateRenderer.test.js
@@ -10,7 +10,6 @@ const mockCertificateTemplates = [
   { id: "template2", template: Template2 }
 ];
 
-const mockUpdateParentHeight = jest.fn();
 const mockUpdateParentTemplates = jest.fn();
 const mockObfuscateDocument = jest.fn();
 const mockCertificate = {
@@ -27,14 +26,12 @@ it("update functions are executed on mount", () => {
       templates={mockCertificateTemplates}
       tabIndex={1}
       document={mockCertificate}
-      updateParentHeight={mockUpdateParentHeight}
       updateParentTemplates={mockUpdateParentTemplates}
       whitelist={mockValidWhiteList}
       obfuscateDocument={mockObfuscateDocument}
     />
   );
 
-  expect(mockUpdateParentHeight).toHaveBeenCalled();
   expect(mockUpdateParentTemplates).toHaveBeenCalled();
 });
 
@@ -44,7 +41,6 @@ it("returns InvalidCertificateNotice if whitelist is wrong", () => {
       templates={mockCertificateTemplates}
       tabIndex={0}
       document={mockCertificate}
-      updateParentHeight={mockUpdateParentHeight}
       updateParentTemplates={mockUpdateParentTemplates}
       whitelist={mockInvalidWhiteList}
     />
@@ -58,7 +54,6 @@ it("returns SelectedTemplateTab if whitelist is correct", () => {
       templates={mockCertificateTemplates}
       tabIndex={1}
       document={mockCertificate}
-      updateParentHeight={mockUpdateParentHeight}
       updateParentTemplates={mockUpdateParentTemplates}
       whitelist={mockValidWhiteList}
       obfuscateDocument={mockObfuscateDocument}
@@ -68,9 +63,6 @@ it("returns SelectedTemplateTab if whitelist is correct", () => {
   const SelectedTemplate = component.find(Template2);
   expect(SelectedTemplate.exists()).toBe(true);
   expect(SelectedTemplate.prop("certificate")).toEqual(mockCertificate);
-  expect(SelectedTemplate.prop("updateParentHeight")).toEqual(
-    mockUpdateParentHeight
-  );
   expect(SelectedTemplate.prop("handleObfuscation")).toEqual(
     mockObfuscateDocument
   );

--- a/src/components/FramelessViewer/FramelessCertificateViewer.js
+++ b/src/components/FramelessViewer/FramelessCertificateViewer.js
@@ -10,7 +10,6 @@ const FramelessCertificateViewer = props => {
   const {
     document,
     tabIndex,
-    updateParentHeight,
     updateParentTemplates,
     obfuscateDocument
   } = props;
@@ -26,7 +25,6 @@ const FramelessCertificateViewer = props => {
     <SelectedTemplate
       document={document}
       tabIndex={tabIndex}
-      updateParentHeight={updateParentHeight}
       updateParentTemplates={updateParentTemplates}
       obfuscateDocument={obfuscateDocument}
     />
@@ -36,7 +34,6 @@ const FramelessCertificateViewer = props => {
 FramelessCertificateViewer.propTypes = {
   document: PropTypes.object,
   tabIndex: PropTypes.number,
-  updateParentHeight: PropTypes.func,
   updateParentTemplates: PropTypes.func,
   obfuscateDocument: PropTypes.func
 };

--- a/src/components/FramelessViewer/FramelessViewerPageContainer.js
+++ b/src/components/FramelessViewer/FramelessViewerPageContainer.js
@@ -6,6 +6,8 @@ import FramelessCertificateViewer from "./FramelessCertificateViewer";
 import { inIframe, formatTemplate } from "./utils";
 
 class FramelessViewerContainer extends Component {
+  observer = null;
+
   constructor(props) {
     super(props);
 
@@ -48,11 +50,22 @@ class FramelessViewerContainer extends Component {
       this.setState({ parentFrameConnection });
     }
 
-    const config = { attributes: true, childList: true, subtree: true };
+    const config = {
+      attributes: true,
+      childList: true,
+      subtree: true,
+      characterData: true
+    };
     // eslint-disable-next-line no-undef
-    const observer = new MutationObserver(this.updateParentHeight);
+    this.observer = new MutationObserver(this.updateParentHeight);
     // eslint-disable-next-line react/no-find-dom-node
-    observer.observe(ReactDOM.findDOMNode(this), config);
+    this.observer.observe(ReactDOM.findDOMNode(this), config);
+    window.addEventListener("resize", this.updateParentHeight);
+  }
+
+  componentWillUnmount() {
+    if (this.observer) this.observer.disconnect();
+    window.removeEventListener("resize", this.updateParentHeight);
   }
 
   async selectTemplateTab(tabIndex) {

--- a/src/components/FramelessViewer/tests/FramelessCertificateViewer.test.js
+++ b/src/components/FramelessViewer/tests/FramelessCertificateViewer.test.js
@@ -34,14 +34,12 @@ it("renders selected template if template key is found", () => {
 it("props are passed correctly to SelectedTemplate", () => {
   const mockCertificate = { $template: "custom" };
   const mockObfuscateDoucment = jest.fn();
-  const mockUpdateParentHeight = jest.fn();
   const mockUpdateParentTemplates = jest.fn();
 
   const component = mount(
     <FramelessCertificateViewer
       document={mockCertificate}
       obfuscateDocument={mockObfuscateDoucment}
-      updateParentHeight={mockUpdateParentHeight}
       updateParentTemplates={mockUpdateParentTemplates}
     />
   );
@@ -49,9 +47,7 @@ it("props are passed correctly to SelectedTemplate", () => {
   expect(component.children().prop("obfuscateDocument")).toEqual(
     mockObfuscateDoucment
   );
-  expect(component.children().prop("updateParentHeight")).toEqual(
-    mockUpdateParentHeight
-  );
+
   expect(component.children().prop("updateParentTemplates")).toEqual(
     mockUpdateParentTemplates
   );

--- a/src/components/FramelessViewer/tests/FramelessViewerPageContainer.test.js
+++ b/src/components/FramelessViewer/tests/FramelessViewerPageContainer.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import FramelessViewerPageContainer from "../FramelessViewerPageContainer";
 import ReactDom from "react-dom";
+import FramelessViewerPageContainer from "../FramelessViewerPageContainer";
 
 const mockObserve = jest.fn();
 global.MutationObserver = jest

--- a/src/components/FramelessViewer/tests/FramelessViewerPageContainer.test.js
+++ b/src/components/FramelessViewer/tests/FramelessViewerPageContainer.test.js
@@ -1,8 +1,21 @@
 import React from "react";
 import { shallow } from "enzyme";
 import FramelessViewerPageContainer from "../FramelessViewerPageContainer";
+import ReactDom from "react-dom";
 
+const mockObserve = jest.fn();
+global.MutationObserver = jest
+  .fn()
+  .mockImplementation(() => ({ observe: mockObserve }));
+
+jest.mock("react-dom");
 jest.mock("../FramelessCertificateViewer", () => jest.fn());
+
+beforeEach(() => {
+  mockObserve.mockClear();
+  global.MutationObserver.mockClear();
+  ReactDom.findDOMNode.mockClear();
+});
 
 it("returns false because of certificateContentsString", () => {
   const component = shallow(<FramelessViewerPageContainer />);
@@ -52,4 +65,15 @@ it("does not crash when updateParentTemplates is called when not in iframe", () 
 it("does not crash when obfuscateDocument is called when not in iframe", () => {
   const component = shallow(<FramelessViewerPageContainer />);
   component.instance().obfuscateDocument();
+});
+
+it("should create MutationObserver observe changes on current node", () => {
+  ReactDom.findDOMNode.mockReturnValue("current node");
+  shallow(<FramelessViewerPageContainer />);
+
+  expect(global.MutationObserver.mock.calls.length).toBe(1);
+  expect(mockObserve.mock.calls[0]).toEqual([
+    "current node",
+    { attributes: true, childList: true, subtree: true }
+  ]);
 });

--- a/src/components/FramelessViewer/tests/FramelessViewerPageContainer.test.js
+++ b/src/components/FramelessViewer/tests/FramelessViewerPageContainer.test.js
@@ -74,6 +74,6 @@ it("should create MutationObserver observe changes on current node", () => {
   expect(global.MutationObserver.mock.calls.length).toBe(1);
   expect(mockObserve.mock.calls[0]).toEqual([
     "current node",
-    { attributes: true, childList: true, subtree: true }
+    { attributes: true, childList: true, subtree: true, characterData: true }
   ]);
 });


### PR DESCRIPTION
Fixes issue with double scroll bar with MutationObserver.

This problem can be replicated by increasing the height of an element in the iframe after the certificate has been rendered. You should see two scrollbars.

The problem with double scroll bar appearing is when the child node of `FramelessViewerPageContainer` has been mounted and the DOM tree is not re-rendered but an element in the descendant nodes has been updated and height changed. This result in `FramelessViewerPageContainer` not being aware of the updates and therefore not firing the `updateParentHeight()` method to tell the iframe's parent the change in height.

MutationObserver solves this by observing any changes (attributes, childList & subtree) to a DOM node and firing a callback (`updateParentHeight`) when change occurs.

This fix needs to be copied to the decentralised render for both TT and OC after merging here.

https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver