### PR TITLE
fix: compute year with reference to SGT timezone

### DIFF
--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/common/template.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/common/template.js
@@ -64,37 +64,22 @@ export const EXAM_LVL_TEXT = {
 
 export const FORMATDATEPREFIX = dateString => {
   const date = new Date(dateString);
-  const day = date.getDate();
-  const month = date.getMonth();
-  const year = date.getFullYear();
-
-  let dayValue = "";
-
-  const months = [
-    "01",
-    "02",
-    "03",
-    "04",
-    "05",
-    "06",
-    "07",
-    "08",
-    "09",
-    "10",
-    "11",
-    "12"
-  ];
-
-  const lengthday = day.toString().length;
-  if (lengthday === 1) {
-    dayValue = `0${day}`;
-  } else {
-    dayValue = day;
-  }
+  const day = date.toLocaleDateString("en-SG", {
+    timeZone: "Asia/Singapore",
+    day: "2-digit",
+  });
+  const month = date.toLocaleDateString("en-SG", {
+    timeZone: "Asia/Singapore",
+    month: "2-digit",
+  });
+  const year = date.toLocaleDateString("en-SG", {
+    timeZone: "Asia/Singapore",
+    year: "numeric",
+  });
 
   return (
     <span>
-      {dayValue}/{months[month]}/{year}
+      {day}/{month}/{year}
     </span>
   );
 };

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/common/template.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/common/template.js
@@ -64,24 +64,14 @@ export const EXAM_LVL_TEXT = {
 
 export const FORMATDATEPREFIX = dateString => {
   const date = new Date(dateString);
-  const day = date.toLocaleDateString("en-SG", {
+  const formattedDateString = date.toLocaleDateString("en-SG", {
     timeZone: "Asia/Singapore",
     day: "2-digit",
-  });
-  const month = date.toLocaleDateString("en-SG", {
-    timeZone: "Asia/Singapore",
     month: "2-digit",
-  });
-  const year = date.toLocaleDateString("en-SG", {
-    timeZone: "Asia/Singapore",
     year: "numeric",
   });
 
-  return (
-    <span>
-      {day}/{month}/{year}
-    </span>
-  );
+  return <span>{formattedDateString}</span>;
 };
 
 export const FORMATYEARPREFIX = dateString => {

--- a/src/components/CertificateTemplates/tlds/sg/gov/seab/common/template.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/seab/common/template.js
@@ -101,7 +101,10 @@ export const FORMATDATEPREFIX = dateString => {
 
 export const FORMATYEARPREFIX = dateString => {
   const date = new Date(dateString);
-  const year = date.getFullYear();
+  const year = date.toLocaleDateString("en-SG", {
+    timeZone: "Asia/Singapore",
+    year: "numeric",
+  });
 
   return year;
 };


### PR DESCRIPTION
## Context
Received MOP feedback that the year rendered in their SEAB O-Level certificate was incorrect (2016). However, checking the `.opencert` file revealed the correct year (2015).

This was caused by a timezone difference depending on which country the document was rendered in. Especially so when `attainmentDate` is the last day and last minute of the year 2015: `2015-12-31T23:59:00+08:00`

An example to illustrate issue:
```javascript
/* Device on Japanese timezone (GMT +09:00) */
const date = new Date('2015-12-31T23:59:00+08:00'); // Fri Jan 01 2016 00:59:00 GMT+0900 (日本標準時)
const year = date.getFullYear(); // 2016
```

## Fix
Incorrect as `.getFullYear()` will obtain the year with respect to the device's timezone:
```javascript
const year = date.getFullYear();
```

Correct as `.toLocaleDateString()` allows you to [specify a timezone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) to use:
```javascript
const year = date.toLocaleDateString("en-SG", {
  timeZone: "Asia/Singapore",
  year: "numeric",
});
```