### PR TITLE
fix: print preview for some wsq templates

### DIFF
--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-005/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-005/certificate.js
@@ -11,10 +11,10 @@ import * as styles from "../common/style";
 
 export const renderLogoWSQ = () => (
   <div className="row d-flex" style={{ marginTop: "3rem" }}>
-    <div className="col-lg-5 col-12">
+    <div className="col-md-5 col-12">
       <img style={styles.fullWidthStyle} src={NICF_LOGO} />
     </div>
-    <div className="col-lg-6" />
+    <div className="col-md-6" />
   </div>
 );
 
@@ -23,13 +23,15 @@ export const renderSignature = certificate => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-
-    <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-      <img style={{width: "100%", height: "auto", marginTop:"40%"}} src={IMG_SEAL} />
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      <img
+        style={{ width: "100%", height: "auto", marginTop: "40%" }}
+        src={IMG_SEAL}
+      />
     </div>
 
-    <div className="col-lg-10 col-12 row d-flex justify-content-center">
-      <div className="col-lg-8">
+    <div className="col-md-10 col-12 row d-flex justify-content-center">
+      <div className="col-md-8">
         <div className="col-12" style={{ padding: "5px" }}>
           <img
             style={styles.signatureWidthStyle}
@@ -54,14 +56,14 @@ export const renderSignature = certificate => (
           System.
         </div>
       </div>
-      <div className="col-lg-4 col-xs-12">
+      <div className="col-md-4 col-xs-12">
         <div style={{ marginBottom: "70px", marginTop: "60px" }}>
           <p style={styles.printTextStyle} className="RobotoRegular">
             Cert No: {get(certificate, "additionalData.serialNum")}
           </p>
         </div>
       </div>
-      <div className="col-lg-5 col-12">
+      <div className="col-md-5 col-12">
         <div style={styles.footerAboutTextStyle} className="RobotoLight">
           <a style={{ color: "rgb(51,0,144)" }} href="www.ssg.gov.sg">
             www.ssg.gov.sg
@@ -77,7 +79,7 @@ export const renderSignature = certificate => (
         </div>
       </div>
       <div
-        className="col-lg-7 col-12 d-flex justify-content-center"
+        className="col-md-7 col-12 d-flex justify-content-center"
         style={{ alignItems: "center" }}
       >
         <div>

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-006/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/FQ-006/certificate.js
@@ -22,11 +22,11 @@ export const effectiveDateForWSQLOGOQual = certificate => {
 
 export const renderLogoWSQ = certificate => (
   <div className="row d-flex" style={{ marginTop: "3rem" }}>
-    <div className="col-lg-5 col-12">
+    <div className="col-md-5 col-12">
       {effectiveDateForWSQLOGOQual(certificate)}
     </div>
-    <div className="col-lg-2 col-12" />
-    <div className="col-lg-5 col-12">
+    <div className="col-md-2 col-12" />
+    <div className="col-md-5 col-12">
       <img style={styles.fullWidthStyleQual} src={DIGIPEN_LOGO} />
     </div>
   </div>
@@ -38,13 +38,13 @@ export const renderSignature = certificate => (
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
 
-    <div className="col-lg-2 col-6" style={{padding:"0px"}}>
+    <div className="col-md-2 col-6" style={{padding:"0px"}}>
       <img style={styles.sealWidthStyle} src={IMG_SEAL} />
     </div>
 
-    <div className="col-lg-10" style={{paddingLeft:"8px"}}>
+    <div className="col-md-10" style={{paddingLeft:"8px"}}>
       <div className="row">
-        <div className="col-lg-6 col-12">
+        <div className="col-md-6 col-12">
           <div className="col-12" style={{height: "65%"}}>
 
             <img
@@ -63,7 +63,7 @@ export const renderSignature = certificate => (
             {get(certificate, "additionalData.certSignatories[0].organisation")}
           </div>
         </div>
-        <div className="col-lg-6 col-12">
+        <div className="col-md-6 col-12">
 
           <div className="col-12" style={{height: "65%"}}>
 
@@ -85,7 +85,7 @@ export const renderSignature = certificate => (
         </div>
       </div>
       <div className="row">
-        <div className="col-lg-7 col-12">
+        <div className="col-md-7 col-12">
           <div style={styles.footerTextStyle} className="RobotoLight">
             The training and assessment of the abovementioned learner are
             accredited
@@ -107,7 +107,7 @@ export const renderSignature = certificate => (
             </a>
           </div>
         </div>
-        <div className="col-lg-5 col-12">
+        <div className="col-md-5 col-12">
           <div
             style={{ marginBottom: "70px", marginTop: "60px", display: "flex" }}
           >

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_001/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/SF_SOA_001/certificate.js
@@ -14,12 +14,13 @@ export const renderSignatureSFSOA = certificate => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-
-    <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-      <img style={{width: "100%", height: "auto",marginTop:"49%"}} src={IMG_SEAL} />
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      <img
+        style={{ width: "100%", height: "auto", marginTop: "49%" }}
+        src={IMG_SEAL}
+      />
     </div>
-
-    <div className="col-lg-7" style={{ paddingLeft: "8px" }}>
+    <div className="col-md-7" style={{ paddingLeft: "8px" }}>
       <div className="col-12" style={{ padding: "5px" }}>
         <img
           style={styles.signatureWidthStyle}
@@ -50,7 +51,7 @@ export const renderSignatureSFSOA = certificate => (
         https://myskillsfuture.sg/verify_eCert.html
       </div>
     </div>
-    <div className="col-lg-3 col-xs-12">
+    <div className="col-md-3 col-xs-12">
       <div style={{ marginBottom: "70px", marginTop: "60px" }}>
         <p style={styles.printTextStyle} className="RobotoRegular">
           Cert No: {get(certificate, "additionalData.serialNum")}

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
@@ -147,7 +147,7 @@ export const renderFooter = certificate => (
 
 export const renderCopyright = () => (
   <div>
-    <div className="d-flex mt-5">
+    <div className="d-flex" style={{ marginTop: "3rem" }}>
       <p style={styles.copyrightStyle} className="RobotoLight">
         Copyright @ 2016 All Rights Reserved SkillsFuture Singapore Agency
       </p>

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
@@ -147,7 +147,7 @@ export const renderFooter = certificate => (
 
 export const renderCopyright = () => (
   <div>
-    <div className="d-flex" style={{ marginTop: "15rem" }}>
+    <div className="d-flex mt-5">
       <p style={styles.copyrightStyle} className="RobotoLight">
         Copyright @ 2016 All Rights Reserved SkillsFuture Singapore Agency
       </p>

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
@@ -25,7 +25,7 @@ const renderTranscriptItems = certificate =>
 
 export const renderLogoWSQ = certificate => (
   <div className="row d-flex">
-    <div className="col-lg-4 col-12">
+    <div className="col-md-4 col-12">
       {effectiveDateForWSQLOGO(certificate)}
     </div>
   </div>
@@ -36,7 +36,7 @@ export const renderSignature = certificate => (
     className="row d-flex justify-content-center align-items-end"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-    <div className="col-lg-7 col-xs-12">
+    <div className="col-md-7 col-xs-12">
       <div style={styles.designationTextStyle} className="RobotoLight">
         {get(certificate, "additionalData.certSignatories[0].position")}
       </div>
@@ -53,8 +53,8 @@ export const renderSignature = certificate => (
         </a>
       </div>
     </div>
-    <div className="col-lg-2 col-xs-12" />
-    <div className="col-lg-3 col-xs-12">
+    <div className="col-md-2 col-xs-12" />
+    <div className="col-md-3 col-xs-12">
       <img style={styles.transFooterLogoStyle} src={IMG_SSGLOGO} />
       {renderTRAcode(certificate)}
     </div>
@@ -67,12 +67,12 @@ export const renderAwardText = certificate => (
       {renderAwardTextTrans(certificate)}
     </div>
     <div className="row d-flex align-items-end" style={{ marginTop: "1rem" }}>
-      <div className="col-lg-10 col-xs-12">
+      <div className="col-md-10 col-xs-12">
         <span style={styles.transNameTextStyle} className="RobotoMedium">
           Name: {certificate.recipient.name}
         </span>
       </div>
-      <div className="col-lg-2 col-xs-12">
+      <div className="col-md-2 col-xs-12">
         <span>{get(certificate, "additionalData.serialNum")}</span>
       </div>
     </div>

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/Trans/certificate.js
@@ -157,7 +157,7 @@ export const renderCopyright = () => (
 
 export const renderQualificationText = certificate => (
   <div>
-    <div className="d-flex" style={{ marginTop: "3rem" }}>
+    <div className="d-flex" style={{ paddingTop: "3rem" }}>
       <p style={styles.printTextStyle} className="RobotoRegular">
         A qualification is awarded to an individual in recognition of his/her
         attainment of the required industry validated competencies under the

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -895,12 +895,14 @@ export const renderSignatureSOACC = certificate => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-
-    <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-    <img style={{  width: "100%",  height: "auto",marginTop:"6%"}} src={IMG_SEAL} />
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      <img
+        style={{ width: "100%", height: "auto", marginTop: "6%" }}
+        src={IMG_SEAL}
+      />
     </div>
 
-    <div className="col-lg-7">
+    <div className="col-md-7">
       <div
         className="col-lg-4 col-12"
         style={{ paddingLeft: "0px", fontSize: "1.5rem" }}
@@ -922,7 +924,7 @@ export const renderSignatureSOACC = certificate => (
       </div>
       {renderFooterText(styles.footerTextStyle)}
     </div>
-    <div className="col-lg-3 col-xs-12">
+    <div className="col-md-3 col-xs-12">
       <div style={{ marginBottom: "70px", marginTop: "60px" }}>
         <p style={styles.printTextStyle} className="RobotoRegular">
           Cert No: {get(certificate, "additionalData.serialNum")}

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -227,10 +227,7 @@ export const switchOperatorFunction = certificate => {
 export const renderSignature = certificate => (
   <div>
     {["QUAL_Reprint"].includes(get(certificate, "additionalData.certCode")) ? (
-      <div
-        className="col-lg-5 col-12"
-        style={{ paddingLeft: "0px", fontSize: "1.5rem" }}
-      >
+      <div style={{ paddingLeft: "0px", fontSize: "1.5rem" }}>
         <p style={{ fontWeight: "bold", color: "#FF0000" }}>Certified Copy</p>
       </div>
     ) : (
@@ -903,10 +900,7 @@ export const renderSignatureSOACC = certificate => (
     </div>
 
     <div className="col-md-7">
-      <div
-        className="col-lg-4 col-12"
-        style={{ paddingLeft: "0px", fontSize: "1.5rem" }}
-      >
+      <div style={{ paddingLeft: "0px", fontSize: "1.5rem" }}>
         <p style={{ fontWeight: "bold", color: "#FF0000" }}>Certified Copy</p>
       </div>
       <div style={styles.designationTextStyle} className="RobotoBold">

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -147,10 +147,10 @@ export const renderIssuingDate = certificate => (
 
 export const renderLogoNICF = () => (
   <div className="row d-flex">
-    <div className="col-lg-4 col-12">
+    <div className="col-md-4 col-12">
       <img style={styles.fullWidthStyle} src={NICF_LOGO} />
     </div>
-    <div className="col-lg-6" />
+    <div className="col-md-6" />
   </div>
 );
 
@@ -421,11 +421,17 @@ export const renderSignatureSOAIT = certificate => (
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
 
-      <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-    <img style={{width: "100%", height: "auto", marginTop:"29%"}} src={IMG_SEAL} />
-     </div>
-    <div className="col-lg-10 col-12 row d-flex justify-content-center" style={{paddingLeft:"8px"}}>
-      <div className="col-lg-8" >
+<div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      <img
+        style={{ width: "100%", height: "auto", marginTop: "29%" }}
+        src={IMG_SEAL}
+      />
+    </div>
+    <div
+      className="col-md-10 col-12 row d-flex justify-content-center"
+      style={{ paddingLeft: "8px" }}
+    >
+      <div className="col-md-8">
         {renderSignature(certificate)}
         <div style={styles.footerTextStyle} className="RobotoLight">
           The training and assessment of the abovementioned learner are
@@ -441,18 +447,18 @@ export const renderSignatureSOAIT = certificate => (
             : ""}
         </div>
       </div>
-      <div className="col-lg-4 col-xs-12">
+      <div className="col-md-4 col-xs-12">
         <div style={{ marginBottom: "70px", marginTop: "60px" }}>
           <p style={styles.printTextStyle} className="RobotoRegular">
             Cert No: {get(certificate, "additionalData.serialNum")}
           </p>
         </div>
       </div>
-      <div className="col-lg-5 col-12">
+      <div className="col-md-5 col-12">
         {renderFooterText(styles.footerAboutTextStyle)}
       </div>
       <div
-        className="col-lg-7 col-12 d-flex justify-content-center"
+        className="col-md-7 col-12 d-flex justify-content-center"
         style={{ alignItems: "center" }}
       >
         <div style={{ margin: "15px" }}>

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -646,7 +646,7 @@ export const renderSignatureSOAHR = certificate => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-    <div className="col-lg-2 col-6" style={{ padding: "0px" }}>
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
       {["QUAL_Reprint"].includes(
         get(certificate, "additionalData.certCode")
       ) ? (
@@ -661,7 +661,7 @@ export const renderSignatureSOAHR = certificate => (
         />
       )}
     </div>
-    <div className="col-lg-6" style={{ paddingLeft: "8px" }}>
+    <div className="col-md-6" style={{ paddingLeft: "8px" }}>
       {renderSignature(certificate)}
       <div style={styles.footerTextStyle} className="RobotoLight">
         The training and assessment of the abovementioned learner are accredited
@@ -683,7 +683,7 @@ export const renderSignatureSOAHR = certificate => (
       {renderFooterText(styles.footerTextStyle)}
     </div>
     <div
-      className="col-lg-4 col-xs-12 d-flex"
+      className="col-md-4 col-xs-12 d-flex"
       style={{ flexDirection: "column" }}
     >
       <div style={{ flex: "1", marginTop: "30px" }}>

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -130,7 +130,7 @@ export const getSpecialization = additionalData => {
 
 export const renderLogoWSQ = certificate => (
   <div className="row d-flex">
-    <div className="col-lg-5 col-12" style={{ paddingRight: "0px" }}>
+    <div className="col-md-5 col-12" style={{ paddingRight: "0px" }}>
       {effectiveDateForWSQLOGO(certificate)}
     </div>
     <div className="col-lg-6" />

--- a/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
+++ b/src/components/CertificateTemplates/tlds/sg/gov/ssg-wsg/common/functions.js
@@ -133,7 +133,7 @@ export const renderLogoWSQ = certificate => (
     <div className="col-md-5 col-12" style={{ paddingRight: "0px" }}>
       {effectiveDateForWSQLOGO(certificate)}
     </div>
-    <div className="col-lg-6" />
+    <div className="col-md-6" />
   </div>
 );
 
@@ -189,9 +189,7 @@ export const renderRecipientID = certificate => (
 );
 
 export const renderSeal = () => (
-
   <div className="col-lg-2 col-6" style={{ padding: "0px" }}>
-
     <img style={styles.sealWidthStyle} src={IMG_SEAL} />
   </div>
 );
@@ -754,11 +752,13 @@ export const renderSignaturePartner = certificate => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-
-     <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-    <img style={{width: "100%", height: "auto",marginTop:"40%"}} src={IMG_SEAL} />
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      <img
+        style={{ width: "100%", height: "auto", marginTop: "40%" }}
+        src={IMG_SEAL}
+      />
     </div>
-    <div className="col-lg-6" style={{paddingLeft:"8px"}}>
+    <div className="col-md-6" style={{ paddingLeft: "8px" }}>
       {renderSignature(certificate)}
       <img style={styles.signatureFooterLogoStyle} src={IMG_SSGLOGO} />
       <div style={styles.minHeightfooterTextStyle} className="RobotoLight">
@@ -769,7 +769,7 @@ export const renderSignaturePartner = certificate => (
       {renderFooterText(styles.footerTextStyle)}
     </div>
     <div
-      className="col-lg-4 col-xs-12 d-flex"
+      className="col-md-4 col-xs-12 d-flex"
       style={{ flexDirection: "column" }}
     >
       <div style={{ flex: "1", marginTop: "60px" }}>
@@ -975,11 +975,13 @@ export const renderSignatureSOAES = certificate => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
-
-     <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-    <img style={{width: "100%",  height: "auto",marginTop:"40%"}} src={IMG_SEAL} />
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      <img
+        style={{ width: "100%", height: "auto", marginTop: "40%" }}
+        src={IMG_SEAL}
+      />
     </div>
-    <div className="col-lg-6" style={{paddingLeft:"5px"}} >
+    <div className="col-md-6" style={{ paddingLeft: "5px" }}>
       {renderSignature(certificate)}
       <img style={styles.signatureFooterLogoStyle} src={IMG_SSGLOGO} />
       <div style={styles.minHeightfooterTextStyle} className="RobotoLight">
@@ -993,7 +995,7 @@ export const renderSignatureSOAES = certificate => (
       </div>
       {renderFooterText(styles.footerTextStyle)}
     </div>
-    <div className="col-lg-4 col-xs-12 d-flex">
+    <div className="col-md-4 col-xs-12 d-flex">
       <div
         className="col-lg-10 col-8"
         style={{ textAlign: "right", alignSelf: "flex-end", padding: "0px" }}
@@ -1036,13 +1038,22 @@ export const renderSignatureQual = (certificate, IMG_BOTTOM_LOGO) => (
     className="row d-flex justify-content-center"
     style={{ marginTop: "8rem", marginBottom: "1rem" }}
   >
- 
-    <div className="col-lg-2 col-6" style={{padding:"0px"}}>
-    {["FQ-004","SF_FQ_004"].includes(get(certificate, "additionalData.certCode"))
-          ? <img style={{width: "100%",  height: "auto",marginTop:"46%"}} src={IMG_SEAL} />
-          : <img style={{width: "100%",  height: "auto",marginTop:"28%"}} src={IMG_SEAL} />}
+    <div className="col-md-2 col-6" style={{ padding: "0px" }}>
+      {["FQ-004", "SF_FQ_004"].includes(
+        get(certificate, "additionalData.certCode")
+      ) ? (
+        <img
+          style={{ width: "100%", height: "auto", marginTop: "46%" }}
+          src={IMG_SEAL}
+        />
+      ) : (
+        <img
+          style={{ width: "100%", height: "auto", marginTop: "28%" }}
+          src={IMG_SEAL}
+        />
+      )}
     </div>
-    <div className="col-lg-6" style={{ paddingLeft: "8px" }} >
+    <div className="col-md-6" style={{ paddingLeft: "8px" }} >
       {renderSignature(certificate)}
       <div style={{ paddingLeft: "0px" }} className="col-lg-5 col-12">
         <img style={styles.footerLogoStyle} src={IMG_SSGLOGO} />
@@ -1101,7 +1112,7 @@ export const renderSignatureQual = (certificate, IMG_BOTTOM_LOGO) => (
         </div>
       </div>
     </div>
-    <div className="col-lg-4 col-xs-12">
+    <div className="col-md-4 col-xs-12">
       <div style={{ marginBottom: "70px", marginTop: "60px" }}>
         <p style={styles.printTextStyle} className="RobotoRegular">
           Cert No: {get(certificate, "additionalData.serialNum")}


### PR DESCRIPTION
## Context
A few certs has misalignment issues. It was due to the logos and signatures expanding, which caused pages to extend beyond to two pages.

## What this PR does
- modified breakpoints to prevent logos from enlarging in print preview for ssg-wsg certs
- minimized margin-top of copyright text as the space between the copyright text and paragraph above is too big, causing the copyright text to be pushed to the 2nd page
- added padding-top to `renderQualificationText` so that it does not come too close to the top edge of a new page (i.e. page 2)