### PR TITLE
20240724 RLM25299 NUS-YALE degree scroll new font style

### DIFF
--- a/src/components/CertificateTemplates/tlds/sg/edu/nus/NUS-YALE-2019/degree.scss
+++ b/src/components/CertificateTemplates/tlds/sg/edu/nus/NUS-YALE-2019/degree.scss
@@ -5,6 +5,16 @@
  $debug: false;
 
  .nus-degree {
+
+    @import url(//fonts.googleapis.com/css2?family=Old+Standard+TT:ital,wght@0,400;0,700;1,400&display=swap);
+    @font-face {
+          font-family: 'Old Standard TT';
+          font-style: normal;
+          font-weight: 400;
+          src: url(https://fonts.gstatic.com/s/oldstandardtt/v20/MwQubh3o1vLImiwAVvYawgcf2eVep1q4dHc.woff2) format('woff2');
+          unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+        }
+
     @if ($debug) {
         table td {
             border: 1px solid blue;
@@ -44,11 +54,11 @@
     .cert-tagline {
         display: inline-block;
         text-transform: uppercase;
-        font-family: 'Times New Roman', Times, serif;
+        font-family: 'Old Standard TT', 'Times New Roman', Times, serif;
         text-align: justify;
-        font-size: 20pt;
+        font-size: 17pt;
         font-weight: bold;
-        letter-spacing: 2pt;
+        letter-spacing: 1pt;
     }
 
     .cert-content-table {
@@ -72,8 +82,8 @@
 
     .cert-degree-title {
         display: float;
-        font-size: 20pt;
-        font-family: 'Times New Roman', Times, serif;
+        font-size: 17pt;
+        font-family: 'Old Standard TT', 'Times New Roman', Times, serif;
         font-variant: small-caps;
         font-feature-settings: smcp;
         font-weight: bold;


### PR DESCRIPTION
---
name: Certificate Template Addition
about: This is the workflow for requesting new certificate templates to be added to
  the OpenCerts repository
title: "[New Template]"
labels: new template
assignees: ''

---

# Pull Request Guidelines for Adding Certificate Templates
This document is a work in progress but here are some basic checks. As these are only basic guidelines, meeting the below doesn't indicate there will be no issues with your pull request.

### Pre-merge checks

- [x] Did not modify any files outside of your organisation's template folder (e.g package-lock.json or anything else)
- [x] Ensure that your code has been [rebased](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) on top of latest OpenCerts master
- [x] Linter issues resolved (Run `npm run lint:fix` to see issues)
- [x] `npm run test` passes
- [x] `npm run test:integration` passes
- [x] [Travis Build passes](https://docs.travis-ci.com/user/for-beginners/)

### Certificate Template 
- [x] No more than 5 templates or 25 added/modified files in the pull request
- [x] Ensure that your .opencert file's data complies with the intentions of the OpenCerts' schema - e.g recipient related information is inside the `recipient` object, etc.
- [x] Integration test for each template that checks that the correct rendering is done given a sample certificate
- [x] Sample certificate file included for each template, located alongside the integration test for each template
- [x] Sample certificates must obviously be a sample certificate
  - [x] Obviously fictitious name
  - [x] Obviously sample signatory images
- [x] No fixed-size raster images as part of certificate layout
- [x] Mobile responsive design
- [x] Date parsing should be localised to template author's timezone
- [x] Webpack chunking code is correct
  - [x] Has chunking code
  - [x] Same chunking code as the other certificates belonging to that institute
- [x] Certificate Store Addresses have been updated
  - [x] Template Whitelist
  - [x] Registry
- [x] Template should not be using resources(images etc.) on the website outside of their own folder (e.g institute logo shouldn't be used from /static because there's no guarantee it will not change)
